### PR TITLE
Fix the issue with proxy identityTrustAnchorsPEM

### DIFF
--- a/install.tf
+++ b/install.tf
@@ -29,7 +29,7 @@ resource "helm_release" "linkerd_ha" {
   }
 }
 
-// Disable HA Mode 
+// Disable HA Mode
 
 resource "helm_release" "linkerd_dev" {
   count      = var.enable_linkerd_ha == false ? 1 : 0
@@ -37,7 +37,7 @@ resource "helm_release" "linkerd_dev" {
   repository = "https://helm.linkerd.io/stable"
   chart      = "linkerd2"
   set_sensitive {
-    name  = "global.identityTrustAnchorsPEM"
+    name  = "identityTrustAnchorsPEM"
     value = tls_self_signed_cert.trustanchor_cert.cert_pem
   }
 


### PR DESCRIPTION
when you are using global.identityTrustAnchorsPEM in set parameter in terraform the proxy sidecar validation get error in these line  
with Please provide the identity trust anchors error. 
this pr fix the issue on terraform 0.14.  
https://github.com/linkerd/linkerd2/blob/48c5f70c399aeaa45ee125deca2253a3f9ce96e4/charts/partials/templates/_proxy.tpl#L73